### PR TITLE
Make it possible to build mapnificent_generator on Go 1.9.3

### DIFF
--- a/mapnificent.go
+++ b/mapnificent.go
@@ -16,9 +16,9 @@ import (
 	"strings"
 	"time"
 
+	mapnificent "./mapnificent.pb"
 	"github.com/golang/protobuf/proto"
 	"github.com/mapnificent/gogtfs"
-	"github.com/mapnificent/mapnificent_generator/mapnificent.pb"
 )
 
 var (
@@ -435,7 +435,6 @@ func GetFrequencies(feed *gtfs.Feed, trips *list.List, line *mapnificent.Mapnifi
 
 		var depTimesCounter uint = 0
 		depTimes := make([]int, tripList.Len())
-
 
 		var lastTrip *gtfs.Trip
 

--- a/mapnificent.pb/mapnificent.pb.go
+++ b/mapnificent.pb/mapnificent.pb.go
@@ -13,7 +13,7 @@ It has these top-level messages:
 */
 package mapnificent
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import math "math"
 
 // Reference imports to suppress errors if they are not otherwise used.


### PR DESCRIPTION
These changes seemed to be enough to make the generator build by way of `go get; go build`.